### PR TITLE
Update quickstart.md

### DIFF
--- a/_i18n/en/_docs/quickstart.md
+++ b/_i18n/en/_docs/quickstart.md
@@ -2,7 +2,7 @@ For the impatient, here's how to do function tracing with Frida:
 
 {% highlight bash %}
 ~ $ pip install frida-tools
-~ $ frida-trace -i "recv*" -i "read*" *twitter*
+~ $ frida-trace -i "recv*" -i "read*" twitter
 recv: Auto-generated handler: …/recv.js
 # (snip)
 recvfrom: Auto-generated handler: …/recvfrom.js


### PR DESCRIPTION
We can't pass some expressions as targets as soon as [frida won't work with "ambiguous names"](https://github.com/frida/frida/issues/125).

Moreover if we pass *twitter* without single quotes bash/sh/other_shell will process it before running frida.